### PR TITLE
formatted some files & separated default TusClient builder

### DIFF
--- a/samples/demo/demo/Program.cs
+++ b/samples/demo/demo/Program.cs
@@ -13,14 +13,14 @@ namespace demo
         
         static async Task Main(string[] args)
         {
-            FileInfo fileInfo = new FileInfo("test.dmg");
             
             var hostUri = new Uri(@"http://localhost:5000/files");
-            var tusClient=TusBuild.DefaultTusClientBuild(hostUri)
+            var tusClient=DefaultTusBuild.DefaultTusClientBuild(hostUri)
                 .Build();
             tusClient.Uploading += printUploadProcess;
             tusClient.UploadFinish += UploadFinish;
             Dictionary<string, string> dir = new Dictionary<string, string>();
+            FileInfo fileInfo = new FileInfo("test.dmg");
             dir["filename"] = fileInfo.FullName;
 
             var fileUrl = await tusClient.Create(fileInfo, dir);

--- a/src/BirdMessenger.BenchMark/Program.cs
+++ b/src/BirdMessenger.BenchMark/Program.cs
@@ -6,7 +6,7 @@ namespace BirdMessenger.BenchMark
     public class Program
     {
         public  static  Uri host = new Uri("http://localhost:5000/files");
-        public static  ITusClient tusClient=TusBuild.DefaultTusClientBuild(host)
+        public static  ITusClient tusClient= DefaultTusBuild.DefaultTusClientBuild(host)
             .Build();
         public static void Main(string[] args)
         {

--- a/src/BirdMessenger.Test/TusBuildUnitTest.cs
+++ b/src/BirdMessenger.Test/TusBuildUnitTest.cs
@@ -19,7 +19,7 @@ namespace BirdMessenger.Test
         public async Task TestCreateTusClientAsync()
         {
 
-            var tusClient=TusBuild.DefaultTusClientBuild(tusHost)
+            var tusClient=DefaultTusBuild.DefaultTusClientBuild(tusHost)
                 
                 .Build();
             var fileInfo = new FileInfo(@"TestFile/test.mp4");
@@ -34,7 +34,7 @@ namespace BirdMessenger.Test
         public async Task TestUploadFilesAsync()
         {
 
-            var tusClient = TusBuild.DefaultTusClientBuild(tusHost)
+            var tusClient = DefaultTusBuild.DefaultTusClientBuild(tusHost)
 
                 .Build();
             var fileInfo = new FileInfo(@"TestFile/test.mp4");
@@ -58,10 +58,10 @@ namespace BirdMessenger.Test
         [Fact]
         public async Task TestConfigTusAsync()
         {
-            var tusClient = TusBuild.DefaultTusClientBuild(tusHost)
+            var tusClient = DefaultTusBuild.DefaultTusClientBuild(tusHost)
                 .Configure(option =>
                 {
-                    option.GetUploadSize = (u) => 10 * 1024 * 1024;
+                    option.GetUploadChunkSize = (u) => 10 * 1024 * 1024;
                 })
                 .Build();
             var fileInfo = new FileInfo(@"TestFile/test.mp4");

--- a/src/BirdMessenger.Test/TusClientUnitTest.cs
+++ b/src/BirdMessenger.Test/TusClientUnitTest.cs
@@ -66,7 +66,7 @@ namespace BirdMessenger.Test
         {
             Uri host = new Uri("http://localhost:6000/files");
             
-            ITusClient tusClient=TusBuild.DefaultTusClientBuild(host)
+            ITusClient tusClient= DefaultTusBuild.DefaultTusClientBuild(host)
                 .Build();
             
             return tusClient;

--- a/src/BirdMessenger/Core/Tus.cs
+++ b/src/BirdMessenger/Core/Tus.cs
@@ -10,11 +10,11 @@ using BirdMessenger.Infrastructure;
 
 namespace BirdMessenger.Core
 {
-    
+
     /// <summary>
     /// Tus implementation class
     /// </summary>
-    public class Tus:ITusCore,ITusExtension
+    public class Tus : ITusCore, ITusExtension
     {
 
         private HttpClient _httpClient;
@@ -23,7 +23,7 @@ namespace BirdMessenger.Core
         {
             _httpClient = httpClient;
         }
-        
+
 
         /// <summary>
         /// 
@@ -31,23 +31,23 @@ namespace BirdMessenger.Core
         /// <param name="url"></param>
         /// <param name="requestCancellationToken"></param>
         /// <returns></returns>
-        public async Task<Dictionary<string, string>> Head(Uri url,CancellationToken requestCancellationToken)
+        public async Task<Dictionary<string, string>> Head(Uri url, CancellationToken requestCancellationToken)
         {
             var httpReqMsg = new HttpRequestMessage(HttpMethod.Head, url);
-            
+
             var response = await _httpClient.SendAsync(httpReqMsg, requestCancellationToken);
 
-            if (response.StatusCode == HttpStatusCode.NotFound 
+            if (response.StatusCode == HttpStatusCode.NotFound
                 || response.StatusCode == HttpStatusCode.Gone
                 || response.StatusCode == HttpStatusCode.Forbidden)
             {
-                throw  new TusException($"response's statusCode is{response.StatusCode.ToString()} ");
+                throw new TusException($"response's statusCode is{response.StatusCode.ToString()} ");
             }
-            
-            Dictionary<string,string> result = new Dictionary<string, string>();
+
+            Dictionary<string, string> result = new Dictionary<string, string>();
             result["Upload-Offset"] = response.GetValueOfHeader("Upload-Offset");
             result["Tus-Resumable"] = response.GetValueOfHeader("Tus-Resumable");
-            
+
             return result;
         }
 
@@ -55,9 +55,9 @@ namespace BirdMessenger.Core
             CancellationToken requestCancellationToken)
         {
             var httpReqMsg = new HttpRequestMessage(new HttpMethod("PATCH"), url);
-            httpReqMsg.Headers.Add("Upload-Offset",offset.ToString());
+            httpReqMsg.Headers.Add("Upload-Offset", offset.ToString());
             //httpReqMsg.Headers.Add("Content-Type","application/offset+octet-stream");
-            
+
             httpReqMsg.Content = new ByteArrayContent(uploadData);
             httpReqMsg.Content.Headers.Add("Content-Type", "application/offset+octet-stream");
 
@@ -66,17 +66,17 @@ namespace BirdMessenger.Core
             {
                 throw new TusException($"patch response statusCode is {response.StatusCode.ToString()}");
             }
-            Dictionary<string,string> result = new Dictionary<string, string>();
+            Dictionary<string, string> result = new Dictionary<string, string>();
             result["Upload-Offset"] = response.GetValueOfHeader("Upload-Offset");
             result["Tus-Resumable"] = response.GetValueOfHeader("Tus-Resumable");
-            
+
             return result;
         }
 
-        public async Task<Dictionary<string, string>> Options(Uri url,CancellationToken requestCancellationToken)
+        public async Task<Dictionary<string, string>> Options(Uri url, CancellationToken requestCancellationToken)
         {
             var httpReqMsg = new HttpRequestMessage(HttpMethod.Options, url);
-            
+
             if (_httpClient.DefaultRequestHeaders.Contains("Tus-Resumable"))
             {
                 _httpClient.DefaultRequestHeaders.Remove("Tus-Resumable");
@@ -85,10 +85,10 @@ namespace BirdMessenger.Core
             var response = await _httpClient.SendAsync(httpReqMsg, requestCancellationToken);
             if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.NoContent)
             {
-                throw  new TusException($"Options response statusCode is {response.StatusCode.ToString()}");
+                throw new TusException($"Options response statusCode is {response.StatusCode.ToString()}");
             }
-            
-            Dictionary<string,string> result = new Dictionary<string, string>();
+
+            Dictionary<string, string> result = new Dictionary<string, string>();
             result["Tus-Version"] = response.GetValueOfHeader("Tus-Version");
             result["Tus-Resumable"] = response.GetValueOfHeader("Tus-Resumable");
             if (response.Headers.Contains("Tus-Extension"))
@@ -103,19 +103,19 @@ namespace BirdMessenger.Core
             return result;
         }
 
-        public async Task<Uri> Creation(Uri url, long uploadLength, string uploadMetadata,CancellationToken requestCancellationToken)
+        public async Task<Uri> Creation(Uri url, long uploadLength, string uploadMetadata, CancellationToken requestCancellationToken)
         {
             var httpReqMsg = new HttpRequestMessage(HttpMethod.Post, url);
-            httpReqMsg.Headers.Add("Upload-Length",uploadLength.ToString());
+            httpReqMsg.Headers.Add("Upload-Length", uploadLength.ToString());
             if (!string.IsNullOrEmpty(uploadMetadata))
             {
-                httpReqMsg.Headers.Add("Upload-Metadata",uploadMetadata);
+                httpReqMsg.Headers.Add("Upload-Metadata", uploadMetadata);
             }
-            
+
             var response = await _httpClient.SendAsync(httpReqMsg, requestCancellationToken);
             if (response.StatusCode != HttpStatusCode.Created)
             {
-                throw  new TusException($"creation response statusCode is {response.StatusCode}");
+                throw new TusException($"creation response statusCode is {response.StatusCode}");
             }
 
             string fileUrlStr = response.GetValueOfHeader("Location");
@@ -134,14 +134,14 @@ namespace BirdMessenger.Core
             return fileUrl;
         }
 
-        public async Task<bool> Delete(Uri url,CancellationToken requestCancellationToken)
+        public async Task<bool> Delete(Uri url, CancellationToken requestCancellationToken)
         {
             var httpReqMsg = new HttpRequestMessage(HttpMethod.Delete, url);
-            
+
             var response = await _httpClient.SendAsync(httpReqMsg, requestCancellationToken);
             if (response.StatusCode != HttpStatusCode.NoContent)
             {
-                throw  new TusException($"delete response statusCode is {response.StatusCode}");
+                throw new TusException($"delete response statusCode is {response.StatusCode}");
             }
 
 

--- a/src/BirdMessenger/Infrastructure/ResponseExtension.cs
+++ b/src/BirdMessenger/Infrastructure/ResponseExtension.cs
@@ -16,7 +16,7 @@ namespace BirdMessenger.Infrastructure
             }
             else
             {
-                throw  new TusException($"no found header of {key}");
+                throw new TusException($"no found header of {key}");
             }
         }
     }

--- a/src/BirdMessenger/Infrastructure/TusRequestException.cs
+++ b/src/BirdMessenger/Infrastructure/TusRequestException.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace BirdMessenger.Infrastructure
 {
-    public class TusException:Exception
+    public class TusException : Exception
     {
-        public TusException(string message):base(message)
+        public TusException(string message) : base(message)
         {
-            
+
         }
     }
 }

--- a/src/BirdMessenger/Infrastructure/TusUploadContext.cs
+++ b/src/BirdMessenger/Infrastructure/TusUploadContext.cs
@@ -13,15 +13,15 @@ namespace BirdMessenger.Infrastructure
             UploadFileInfo = uploadFileInfo;
             UploadFileUrl = uploadFileUrl;
         }
-        
-        public   long TotalSize { get; }
 
-        public   long UploadedSize { get; set; }
+        public long TotalSize { get; }
 
-        public  FileInfo UploadFileInfo { get; }
-        
-        public  Uri UploadFileUrl { get;}
-        
-        public  Dictionary<object,object> Items { get; set; }
+        public long UploadedSize { get; set; }
+
+        public FileInfo UploadFileInfo { get; }
+
+        public Uri UploadFileUrl { get; }
+
+        public Dictionary<object, object> Items { get; set; }
     }
 }

--- a/src/BirdMessenger/TusClient.cs
+++ b/src/BirdMessenger/TusClient.cs
@@ -10,36 +10,36 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace BirdMessenger
 {
-    public class TusClient:ITusClient
+    public class TusClient : ITusClient
     {
         private readonly Uri _serverHost;
-        
+
         /// <summary>
         /// 
         /// return size which will upload
         /// </summary>
-        private Func<TusUploadContext,int> GetUploadSize;
+        private Func<TusUploadContext, int> GetUploadSize;
 
         public event Action<TusUploadContext> UploadFinish;
 
         /// <summary>
         /// uri  offset fileLength 
         /// </summary>
-        public event Action<TusUploadContext> Uploading; 
-        
-        private  ITusCore _tusCore;
+        public event Action<TusUploadContext> Uploading;
+
+        private ITusCore _tusCore;
         private ITusExtension _tusExtension;
 
-        public TusClient(ITusCore tusCore,ITusExtension tusExtension,Uri serverHost, Func<TusUploadContext,int> getUploadSize=null)
+        public TusClient(ITusCore tusCore, ITusExtension tusExtension, Uri serverHost, Func<TusUploadContext, int> getUploadSize = null)
         {
             _tusCore = tusCore;
             _tusExtension = tusExtension;
-            
+
             _serverHost = serverHost;
             GetUploadSize = getUploadSize ?? ((context) => 1 * 1024 * 1024);
         }
 
-        
+
 
         /// <summary>
         /// upload file
@@ -48,13 +48,13 @@ namespace BirdMessenger
         /// <param name="uploadFileInfo"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public async Task<bool> Upload(Uri url,FileInfo uploadFileInfo,CancellationToken ct=default(CancellationToken))
+        public async Task<bool> Upload(Uri url, FileInfo uploadFileInfo, CancellationToken ct = default(CancellationToken))
         {
             var headResult = await _tusCore.Head(url, ct);
             long offset = long.Parse(headResult["Upload-Offset"]);
 
-            var tusUploadFileContext = new TusUploadContext(totalSize:uploadFileInfo.Length,
-                uploadedSize:offset,uploadFileInfo:uploadFileInfo,uploadFileUrl:url);
+            var tusUploadFileContext = new TusUploadContext(totalSize: uploadFileInfo.Length,
+                uploadedSize: offset, uploadFileInfo: uploadFileInfo, uploadFileUrl: url);
 
             using (var fileStream = new FileStream(uploadFileInfo.FullName, FileMode.Open, FileAccess.Read))
             {
@@ -65,9 +65,9 @@ namespace BirdMessenger
                         UploadFinish?.Invoke(tusUploadFileContext);
                         break;
                     }
-                    
+
                     //get buffer of file
-                    fileStream.Seek (offset, SeekOrigin.Begin);
+                    fileStream.Seek(offset, SeekOrigin.Begin);
 
                     int uploadSize = GetUploadSize(tusUploadFileContext);
 
@@ -75,10 +75,10 @@ namespace BirdMessenger
                     var readCount = await fileStream.ReadAsync(buffer, 0, uploadSize);
                     if (readCount < uploadSize)
                     {
-                        Array.Resize (ref buffer, readCount);
+                        Array.Resize(ref buffer, readCount);
                     }
 
-                    var uploadResult=await _tusCore.Patch(url, buffer, offset, ct);
+                    var uploadResult = await _tusCore.Patch(url, buffer, offset, ct);
                     offset = long.Parse(uploadResult["Upload-Offset"]);
                     tusUploadFileContext.UploadedSize = offset;
                     Uploading?.Invoke(tusUploadFileContext);
@@ -95,12 +95,12 @@ namespace BirdMessenger
         /// <param name="uploadMetaDic"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public async Task<Uri> Create(FileInfo fileInfo, Dictionary<string, string> uploadMetaDic=null,CancellationToken ct=default(CancellationToken))
+        public async Task<Uri> Create(FileInfo fileInfo, Dictionary<string, string> uploadMetaDic = null, CancellationToken ct = default(CancellationToken))
         {
-            
+
 
             string uploadMeta = this.CreateMeta(fileInfo, uploadMetaDic);
-            var fileUrl = await _tusExtension.Creation(_serverHost, fileInfo.Length,uploadMeta, ct);
+            var fileUrl = await _tusExtension.Creation(_serverHost, fileInfo.Length, uploadMeta, ct);
 
             return fileUrl;
         }
@@ -111,42 +111,42 @@ namespace BirdMessenger
         /// <param name="fileUrl"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public async Task<bool> DeleteFile(Uri fileUrl, CancellationToken ct=default(CancellationToken))
+        public async Task<bool> DeleteFile(Uri fileUrl, CancellationToken ct = default(CancellationToken))
         {
             var deleteResult = await _tusExtension.Delete(fileUrl, ct);
             return deleteResult;
         }
 
-        
-        public async Task<Dictionary<string, string>> ServerInfo(CancellationToken ct=default(CancellationToken))
+
+        public async Task<Dictionary<string, string>> ServerInfo(CancellationToken ct = default(CancellationToken))
         {
             var serverInfoDic = await _tusCore.Options(_serverHost, ct);
             return serverInfoDic;
         }
 
-        private string CreateMeta (FileInfo fileInfo,Dictionary<string, string> uploadMetaDic)
+        private string CreateMeta(FileInfo fileInfo, Dictionary<string, string> uploadMetaDic)
         {
             string uploadMeta = "";
 
             if (uploadMetaDic == null)
             {
-                uploadMetaDic= new Dictionary<string, string>();
+                uploadMetaDic = new Dictionary<string, string>();
             }
 
-            if (!uploadMetaDic.ContainsKey ("fileName"))
+            if (!uploadMetaDic.ContainsKey("fileName"))
             {
                 uploadMetaDic["fileName"] = fileInfo.Name;
             }
 
-            List<string> UploadMetaList = new List<string> ();
+            List<string> UploadMetaList = new List<string>();
             foreach (var item in uploadMetaDic)
             {
-                string key = item.Key.Replace (" ", "").Replace (",", "");
-                string value = Convert.ToBase64String (System.Text.Encoding.UTF8.GetBytes (item.Value));
-                UploadMetaList.Add ($"{key} {value}");
+                string key = item.Key.Replace(" ", "").Replace(",", "");
+                string value = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(item.Value));
+                UploadMetaList.Add($"{key} {value}");
             }
 
-            uploadMeta = string.Join (",", UploadMetaList.ToArray ());
+            uploadMeta = string.Join(",", UploadMetaList.ToArray());
 
             return uploadMeta;
         }


### PR DESCRIPTION
"added default tus builder with default tus builder options to allow manipulation of http client builders for default tus builder"

The main idea is that because the default TusBuilder lives in its own DI context, one cannot add an authentication layer for tus requests. Obviously one could already copy the code from the existing source to replicate what TusBuilder.DefaultTusClientBuild does but we could just as well provide a way for someone to access the HttpClientBuilders generated by DefaultTusClientBuild allowing easier usage. 

In this patch I also formatted some files.

