### PR TITLE
Reduced memory allocations while checking if a custom header is not reserved.

### DIFF
--- a/src/BirdMessenger/Abstractions/TusRequestOptionBase.cs
+++ b/src/BirdMessenger/Abstractions/TusRequestOptionBase.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using BirdMessenger.Constants;
-using BirdMessenger.Delegates;
 using BirdMessenger.Events;
 using BirdMessenger.Infrastructure;
 
@@ -16,12 +15,12 @@ public abstract class TusRequestOptionBase
     {
         HttpHeaders = new Dictionary<string, string>();
     }
-    
+
     /// <summary>
     /// invoke before sending http request to server
     /// </summary>
     public Func<PreSendRequestEvent,Task>? OnPreSendRequestAsync { get; set; }
-    
+
     /// <summary>
     /// add additional http headers
     /// </summary>
@@ -32,7 +31,7 @@ public abstract class TusRequestOptionBase
     internal void AddCustomHttpHeaders(HttpRequestMessage httpRequestMessage)
     {
         ValidateHttpHeaders();
-        
+
         if (HttpHeaders is not null && HttpHeaders.Any())
         {
             foreach (var key in HttpHeaders.Keys)
@@ -41,10 +40,10 @@ public abstract class TusRequestOptionBase
             }
         }
     }
-    
+
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <returns></returns>
     private void ValidateHttpHeaders()
@@ -53,9 +52,9 @@ public abstract class TusRequestOptionBase
         {
             foreach (var headerKey in HttpHeaders.Keys)
             {
-                if (TusHeaders.TusReservedWords.Contains(headerKey.ToLower()))
+                if (TusHeaders.IsReserved(headerKey))
                 {
-                    throw new TusException($"HttpHeader can not contain tus Reserved word:{headerKey}");
+                    throw new TusException($"HttpHeader can not contain tus Reserved word: {headerKey}");
                 }
             }
         }

--- a/src/BirdMessenger/Constants/TusHeaders.cs
+++ b/src/BirdMessenger/Constants/TusHeaders.cs
@@ -1,50 +1,56 @@
+using System;
 using System.Collections.Generic;
 
 namespace BirdMessenger.Constants;
 
-internal static class TusHeaders
+public static class TusHeaders
 {
+    private static readonly HashSet<string> TusReservedWords = new(StringComparer.OrdinalIgnoreCase);
+
     static TusHeaders()
     {
-        TusReservedWords.Add(UploadLength.ToLower());
-        TusReservedWords.Add(UploadOffset.ToLower());
-        TusReservedWords.Add(UploadMetadata.ToLower());
-        TusReservedWords.Add(UploadDeferLength.ToLower());
-        TusReservedWords.Add(ContentType.ToLower());
-        TusReservedWords.Add(UploadChecksum.ToLower());
-        TusReservedWords.Add(TusResumable.ToLower());
-        TusReservedWords.Add(UploadConcat.ToLower());
-        TusReservedWords.Add(TusVersion.ToLower());
-        TusReservedWords.Add(TusMaxSize.ToLower());
-        TusReservedWords.Add(TusExtension.ToLower());
+        TusReservedWords.Add(UploadLength);
+        TusReservedWords.Add(UploadOffset);
+        TusReservedWords.Add(UploadMetadata);
+        TusReservedWords.Add(UploadDeferLength);
+        TusReservedWords.Add(ContentType);
+        TusReservedWords.Add(UploadChecksum);
+        TusReservedWords.Add(TusResumable);
+        TusReservedWords.Add(UploadConcat);
+        TusReservedWords.Add(TusVersion);
+        TusReservedWords.Add(TusMaxSize);
+        TusReservedWords.Add(TusExtension);
     }
-    internal static readonly HashSet<string> TusReservedWords = new();
-    
-    internal const string UploadLength = "Upload-Length";
 
-    internal const string UploadOffset = "Upload-Offset";
-    
-    internal const string UploadMetadata = "Upload-Metadata";
-    
-    internal const string TusResumable = "Tus-Resumable";
+    public const string UploadLength = "Upload-Length";
 
-    internal const string Location = "Location";
-    
-    internal const string UploadDeferLength = "Upload-Defer-Length";
-    
-    internal const string ContentType = "Content-Type";
-    
-    internal const string UploadChecksum = "Upload-Checksum";
-    
-    internal const string UploadConcat = "Upload-Concat";
-    
-    internal const string UploadContentTypeValue= "application/offset+octet-stream";
-    
-    internal const string TusVersion = "Tus-Version";
-    
-    internal const string TusMaxSize = "Tus-Max-Size";
-    
-    internal const string TusExtension = "Tus-Extension";
-    
-    
+    public const string UploadOffset = "Upload-Offset";
+
+    public const string UploadMetadata = "Upload-Metadata";
+
+    public const string TusResumable = "Tus-Resumable";
+
+    public const string Location = "Location";
+
+    public const string UploadDeferLength = "Upload-Defer-Length";
+
+    public const string ContentType = "Content-Type";
+
+    public const string UploadChecksum = "Upload-Checksum";
+
+    public const string UploadConcat = "Upload-Concat";
+
+    public const string UploadContentTypeValue= "application/offset+octet-stream";
+
+    public const string TusVersion = "Tus-Version";
+
+    public const string TusMaxSize = "Tus-Max-Size";
+
+    public const string TusExtension = "Tus-Extension";
+
+    public static bool IsReserved(string headerName)
+    {
+        return string.IsNullOrWhiteSpace(headerName) is false &&
+               TusReservedWords.Contains(headerName);
+    }
 }


### PR DESCRIPTION
- `StringComparer.OrdinalIgnoreCase` is passed to `TusReservedWords` constructor which allows us not to use `.ToLower()` to compare headers.
- Most members of `TusHeaders` were made public as well as `TusHeaders` itself as the library users have to duplicate the class if they want to use the system headers.
- `TusReservedWords` was encapsulated to prevent users from using it directly.