### PR TITLE
fix(HEAD request): throw exception if response is not 200 and not 204

### DIFF
--- a/src/BirdMessenger/HttpClientExtension.cs
+++ b/src/BirdMessenger/HttpClientExtension.cs
@@ -139,10 +139,9 @@ public static class HttpClientExtension
             PreSendRequestEvent preSendRequestEvent = new PreSendRequestEvent(reqOption, httpReqMsg);
             await reqOption.OnPreSendRequestAsync(preSendRequestEvent);
         }
-        var response = await httpClient.SendAsync(httpReqMsg, ct); 
-        if (response.StatusCode == HttpStatusCode.NotFound || 
-            response.StatusCode == HttpStatusCode.Gone     ||
-            response.StatusCode == HttpStatusCode.Forbidden)
+        var response = await httpClient.SendAsync(httpReqMsg, ct);
+        if (response.StatusCode != HttpStatusCode.OK &&
+            response.StatusCode != HttpStatusCode.NoContent)
         {
             throw new TusException($" head response statusCode is{response.StatusCode.ToString()} ",httpReqMsg,response);
         }


### PR DESCRIPTION
## **Problem:**
Currently, for the `HEAD` request the client handles only specific `HttpStatusCode`s like 404, 410, and 403, but does not properly handle other incorrect status codes. When the client receives any unhandled incorrect `HttpStatusCode`, it continues further and throws a confusing `"no found header of Tus-Resumable"` exception.

In my case, when the client received bad `Location` value from `create` request and then tried to `upload`, the reverse proxy returned response 301, which client didn't logged out as an incorrect status code.

## **Solution:**
This PR helps to handle **all** incorrect `HttpStatusCode`s properly, not only 404, 410 and 403.

Resolves #58 